### PR TITLE
Problem: true out of order events are not tested

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,11 +64,11 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.7'
 
     compile 'org.projectlombok:lombok:1.16.8'
-    testCompile 'org.testng:testng:6.9.10'
 
-    compile 'com.eventsourcing:eventsourcing-core:0.3.0'
+    compile 'com.eventsourcing:eventsourcing-core:0.3.2'
     compile 'org.unprotocols:coss:1.0.0'
 
+    testCompile 'org.testng:testng:6.9.10'
 }
 
 test.useTestNG()

--- a/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
+++ b/src/main/java/com/eventsourcing/cep/events/DescriptionChanged.java
@@ -16,10 +16,12 @@ import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import org.unprotocols.coss.RFC;
 import org.unprotocols.coss.Draft;
+import org.unprotocols.coss.RFC;
 
 import java.util.UUID;
+
+import static com.eventsourcing.index.IndexEngine.IndexFeature.*;
 
 /**
  * This event signifies a description change for a referenced instance.
@@ -49,7 +51,7 @@ public class DescriptionChanged extends Event {
         }
     };
 
-    @Index
+    @Index({LT, GT, EQ})
     public static SimpleAttribute<DescriptionChanged, HybridTimestamp> TIMESTAMP = new SimpleAttribute<DescriptionChanged, HybridTimestamp>
             ("timestamp") {
         @Override public HybridTimestamp getValue(DescriptionChanged descriptionChanged, QueryOptions queryOptions) {

--- a/src/main/java/com/eventsourcing/cep/events/NameChanged.java
+++ b/src/main/java/com/eventsourcing/cep/events/NameChanged.java
@@ -12,14 +12,19 @@ import com.eventsourcing.annotations.Index;
 import com.eventsourcing.hlc.HybridTimestamp;
 import com.eventsourcing.index.SimpleAttribute;
 import com.eventsourcing.layout.LayoutName;
+import com.google.common.primitives.UnsignedLongs;
 import com.googlecode.cqengine.query.option.QueryOptions;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import org.unprotocols.coss.RFC;
 import org.unprotocols.coss.Draft;
+import org.unprotocols.coss.RFC;
 
 import java.util.UUID;
+
+import static com.eventsourcing.index.IndexEngine.IndexFeature.EQ;
+import static com.eventsourcing.index.IndexEngine.IndexFeature.GT;
+import static com.eventsourcing.index.IndexEngine.IndexFeature.LT;
 
 /**
  * This event signifies the name change for a referenced instance.
@@ -49,7 +54,7 @@ public class NameChanged extends Event {
         }
     };
 
-    @Index
+    @Index({LT, GT, EQ})
     public static SimpleAttribute<NameChanged, HybridTimestamp> TIMESTAMP = new SimpleAttribute<NameChanged, HybridTimestamp>
             ("timestamp") {
         @Override public HybridTimestamp getValue(NameChanged nameChanged, QueryOptions queryOptions) {

--- a/src/test/java/com/eventsourcing/cep/protocols/RepositoryTest.java
+++ b/src/test/java/com/eventsourcing/cep/protocols/RepositoryTest.java
@@ -8,6 +8,7 @@
 package com.eventsourcing.cep.protocols;
 
 import com.eventsourcing.*;
+import com.eventsourcing.hlc.NTPServerTimeProvider;
 import com.eventsourcing.index.MemoryIndexEngine;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -17,6 +18,7 @@ public abstract class RepositoryTest {
     private final Package[] packages;
     protected Repository repository;
     protected MemoryLockProvider lockProvider;
+    protected NTPServerTimeProvider timeProvider;
 
     public RepositoryTest(Package ...packages) {
         this.packages = packages;
@@ -25,7 +27,9 @@ public abstract class RepositoryTest {
 
     @BeforeMethod
     public void setUp() throws Exception {
+        timeProvider = new NTPServerTimeProvider(new String[]{"localhost"});
         repository = Repository.create();
+        repository.setPhysicalTimeProvider(timeProvider);
         repository.setJournal(new MemoryJournal());
         repository.setIndexEngine(new MemoryIndexEngine());
         lockProvider = new MemoryLockProvider();


### PR DESCRIPTION
Solution: precompute event timestamp to test whether publishing
an event with an older timestamp will affect the changes.

Depends on https://github.com/eventsourcing/es4j/pull/56 being merged.